### PR TITLE
Fixing a bug in functionality which allows users to read collections …

### DIFF
--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -272,13 +272,17 @@
         "login": "LOGIN_NAME",
         "comment_password": "optional. Required if Vault integration is not used",
         "password": "PASSWORD",
-        "comment_overrideconnector":"Optional;Default value: false. use this flag to have DataPull read each MongoDB Document as a whole JSON into a field called jsonfield in the resultset. This is the recommended approach when reading MongoDB collections that have documents that do not conform to a single schema.",
-        "overrideconnector":false,
-        "comment_sparkoptions":"Optional, this is to enable users to use mongo specific configurations. all options can be found at the official spark mongo documentation: https://docs.mongodb.com/spark-connector/master/configuration/",
-        "sparkoptions":{
-          "replaceDocument":true,
-          "ordered":false,
-          "readPreference.name":"Primary"
+        "comment_overrideconnector": "Optional;Default value: false. use this flag to have DataPull read each MongoDB Document as a whole JSON into a field called jsonfield in the resultset. This is the recommended approach when reading MongoDB collections that have documents that do not conform to a single schema.",
+        "overrideconnector": false,
+        "comment_tmpfilelocation": "this is required when the oveerideconnector option is enabled to store the temp data while reading data from mongo. it can be a s3 location nor any random location in the spark nodes",
+        "tmpfilelocation": "S3_LOCATION_OR_ANY_RANDOM_DIRECTORY",
+        "comment_samplesize": "Optional, this is to set sampling of the mongo driver to fetch the schema for a collection.The default value for this 1000. this can be used if we have varying schemas but not varying data types for a single field",
+        "samplesize": "1000",
+        "comment_sparkoptions": "Optional, this is to enable users to use mongo specific configurations. all options can be found at the official spark mongo documentation: https://docs.mongodb.com/spark-connector/master/configuration/",
+        "sparkoptions": {
+          "replaceDocument": true,
+          "ordered": false,
+          "readPreference.name": "Primary"
         },
         "cpmment_pre_migrate_command": "Optional, this feauture will allow users to run pre migrate command for any operations on the collections",
         "pre_migrate_command": "{ delete: \"datapull_test\",deletes: [ { q: { user: \"abc123\" }, limit: 1 } ] }",

--- a/core/src/main/resources/Samples/Input_Sample_filesystem-to-Email.json
+++ b/core/src/main/resources/Samples/Input_Sample_filesystem-to-Email.json
@@ -1,0 +1,26 @@
+{
+  "migrations": [
+    {
+      "source": {
+        "platform": "filesystem",
+        "path": "/Users/yourname/Desktop/Sample-Optmeio-report.json",
+        "fileformat": "json"
+      },
+      "destination": {
+        "platform": "Email",
+        "to": "yourname@expediagroup.com",
+        "subject":"Test",
+        "limit":"100",
+        "truncate":"100"
+      }
+    }
+  ],
+  "cluster": {
+    "pipelinename": "ekg",
+    "awsenv": "dev",
+    "portfolio": "Data Engineering Services",
+    "product": "Data Engineering - COE",
+    "ec2instanceprofile": "Iam role",
+    "cronexpression":"21 * * * *"
+  }
+}

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -61,6 +61,11 @@ import scala.collection.immutable.List
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer, StringBuilder}
 import scala.util.control.Breaks._
+import DataPull.{jsonArrayPropertiesToList, jsonObjectPropertiesToMap}	
+import com.fasterxml.jackson.databind.ObjectMapper	
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory	
+import javax.mail.{Message, Session, Transport}	
+import javax.mail.internet.{InternetAddress, MimeMessage}
 
 class DataFrameFromTo(appConfig: AppConfig, pipeline : String) extends Serializable {
 

--- a/core/src/main/scala/core/DataPull.scala
+++ b/core/src/main/scala/core/DataPull.scala
@@ -73,6 +73,8 @@ object DataPull {
       isLocal = false
     }
 
+
+
     var reportEmailAddress = ""
     var authenticatedUser = ""
     var precisecounts = false
@@ -252,7 +254,7 @@ object DataPull {
       throw new helper.CustomListOfExceptions(migrationErrors.mkString("\n"))
     }
   }
-
+  
   def getFile(fileName: String, relativeToClass:Boolean = true): String = {
 
     val result = new StringBuilder("")
@@ -288,6 +290,16 @@ object DataPull {
 
   def jsonObjectPropertiesToMap(properties: List[String], jsonObject: JSONObject): Map[String, String] = {
     properties map (property => property -> (if (jsonObject.has(property)) jsonObject.getString(property) else "")) toMap
+  }
+
+  def jsonArrayPropertiesToList(jsonStringArr: String) = {
+    var returnList = List.empty[String]
+    val jsonArray = new JSONArray(jsonStringArr)
+    val length = jsonArray.length()
+    for( i <- 0 to length-1){
+      returnList = returnList :+ jsonArray.get(i).toString()
+    }
+    returnList
   }
 
   def uuid(): String = {

--- a/core/src/main/scala/core/DataPull.scala
+++ b/core/src/main/scala/core/DataPull.scala
@@ -20,7 +20,6 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.time._
 import java.util.{Scanner, UUID}
-import javax.net.ssl._
 
 import com.datastax.driver.core.utils.UUIDs
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -28,6 +27,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.mongodb.spark.sql.fieldTypes.Binary
 import config.AppConfig
 import helper._
+import javax.net.ssl._
 import logging._
 import org.apache.commons.codec.binary.{Base64, Hex}
 import org.apache.spark.sql.SparkSession
@@ -72,8 +72,6 @@ object DataPull {
       jsonString = args(0)
       isLocal = false
     }
-
-
 
     var reportEmailAddress = ""
     var authenticatedUser = ""
@@ -254,7 +252,7 @@ object DataPull {
       throw new helper.CustomListOfExceptions(migrationErrors.mkString("\n"))
     }
   }
-  
+
   def getFile(fileName: String, relativeToClass:Boolean = true): String = {
 
     val result = new StringBuilder("")

--- a/core/src/main/scala/core/Migration.scala
+++ b/core/src/main/scala/core/Migration.scala
@@ -42,8 +42,8 @@ class Migration extends  SparkListener {
   def migrate(migrationJSONString: String, reportEmailAddress: String, migrationId: String, verifymigration: Boolean, reportCounts: Boolean, no_of_retries: Int, custom_retries: Boolean, migrationLogId: String, isLocal: Boolean, preciseCounts: Boolean, appConfig: AppConfig, pipeline : String): Map[String, String] = {
     var s3TempFolderDeletionError = StringBuilder.newBuilder
     val reportRowHtml = StringBuilder.newBuilder
-    val migration = new JSONObject(migrationJSONString)
-    var dataPullLogs = new DataPullLog(appConfig, pipeline)
+    val migration: JSONObject = new JSONObject(migrationJSONString)
+    val dataPullLogs = new DataPullLog(appConfig, pipeline)
     this.appConfig = appConfig;
 
     var sparkSession: SparkSession = null
@@ -294,10 +294,9 @@ class Migration extends  SparkListener {
 
       if (reportEmailAddress != "") {
         sparkSession.sparkContext.setJobDescription("Count destination " + migrationId)
-        if (verifymigration)
-        {
-          var dfd = jsonSourceDestinationToDataFrame(sparkSession, destination,migrationLogId,jobId,s3TempFolderDeletionError, pipeline)
-          verified =verifymigrations(df, dfd,sparkSession)
+        if (verifymigration) {
+          var dfd = jsonSourceDestinationToDataFrame(sparkSession, destination, migrationLogId, jobId, s3TempFolderDeletionError, pipeline)
+          verified = verifymigrations(df, dfd, sparkSession)
 
         }
       }
@@ -430,7 +429,7 @@ class Migration extends  SparkListener {
     else if (platform == "hive") {
       dataframeFromTo.hiveToDataFrame(propertiesMap("cluster"), propertiesMap("clustertype"), propertiesMap("database"), propertiesMap("table"))
     } else if (platform == "mongodb") {
-      dataframeFromTo.mongodbToDataFrame(propertiesMap("awsenv"), propertiesMap("cluster"), propertiesMap.getOrElse("overrideconnector", "false"), propertiesMap("database"), propertiesMap("authenticationdatabase"), propertiesMap("collection"), propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("vaultenv"), platformObject.optJSONObject("sparkoptions"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("authenticationenabled", true).asInstanceOf[Boolean])
+      dataframeFromTo.mongodbToDataFrame(propertiesMap("awsenv"), propertiesMap("cluster"), propertiesMap.getOrElse("overrideconnector", "false"), propertiesMap("database"), propertiesMap("authenticationdatabase"), propertiesMap("collection"), propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("vaultenv"), platformObject.optJSONObject("sparkoptions"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("authenticationenabled", "true"), propertiesMap.getOrElse("s3location", null), propertiesMap.getOrElse("samplesize", null))
     }
     else if (platform == "kafka") {
       dataframeFromTo.kafkaToDataFrame(propertiesMap("bootstrapServers"), propertiesMap("topic"), propertiesMap("offset"), propertiesMap("schemaRegistries"), propertiesMap.getOrElse("keydeserializer", "org.apache.kafka.common.serialization.StringDeserializer"), propertiesMap("deSerializer"), propertiesMap.getOrElse("s3location", appConfig.s3bucket.toString + "/datapull-opensource/logs/"), propertiesMap.getOrElse("groupid", null), propertiesMap.getOrElse("requiredonlyvalue", "false"), propertiesMap.getOrElse("payloadcolumnname", "body"), migrationId, jobId, sparkSession, s3TempFolderDeletionError)

--- a/core/src/main/scala/core/Migration.scala
+++ b/core/src/main/scala/core/Migration.scala
@@ -191,7 +191,12 @@ class Migration extends  SparkListener {
       if (destinationMap("platform") == "cassandra") {
         destinationMap = destinationMap ++ deriveClusterIPFromConsul(destinationMap)
         dataframeFromTo.dataFrameToCassandra(destinationMap("awsenv"), destinationMap("cluster"), destinationMap("keyspace"), destinationMap("table"), destinationMap("login"), destinationMap("password"), destinationMap("local_dc"), destination.optJSONObject("sparkoptions"), dft, reportRowHtml, destinationMap("vaultenv"),destinationMap.getOrElse("secretstore","vault"))
-      } else if (destinationMap("platform") == "mssql" || destinationMap("platform") == "mysql" || destinationMap("platform") == "postgres" || destinationMap("platform") == "oracle" || destinationMap("platform") == "teradata") {
+      }
+      else if(destinationMap("platform") == "Email")
+      {
+        dataframeFromTo.dataFrameToEmail(destinationMap.getOrElse("to",reportEmailAddress),destinationMap.getOrElse("subject","Datapull Result"),dft,destinationMap.getOrElse("limit","100"),destinationMap.getOrElse("truncate","100"))
+      }
+      else if (destinationMap("platform") == "mssql" || destinationMap("platform") == "mysql" || destinationMap("platform") == "postgres" || destinationMap("platform") == "oracle" || destinationMap("platform") == "teradata") {
         dataframeFromTo.dataFrameToRdbms(destinationMap("platform"), destinationMap("awsenv"), destinationMap("server"), destinationMap("database"), destinationMap("table"), destinationMap("login"), destinationMap("password"), dft, destinationMap("vaultenv"), destinationMap.getOrElse("secretstore", "vault"), destinationMap.getOrElse("sslenabled", "false"), destinationMap.getOrElse("vault", null), destination.optJSONObject("jdbcoptions"),destinationMap.getOrElse("savemode", "Append"))
       } else if (destinationMap("platform") == "s3") {
         setAWSCredentials(sparkSession, destinationMap)

--- a/core/src/main/scala/core/Migration.scala
+++ b/core/src/main/scala/core/Migration.scala
@@ -429,7 +429,7 @@ class Migration extends  SparkListener {
     else if (platform == "hive") {
       dataframeFromTo.hiveToDataFrame(propertiesMap("cluster"), propertiesMap("clustertype"), propertiesMap("database"), propertiesMap("table"))
     } else if (platform == "mongodb") {
-      dataframeFromTo.mongodbToDataFrame(propertiesMap("awsenv"), propertiesMap("cluster"), propertiesMap.getOrElse("overrideconnector", "false"), propertiesMap("database"), propertiesMap("authenticationdatabase"), propertiesMap("collection"), propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("vaultenv"), platformObject.optJSONObject("sparkoptions"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("authenticationenabled", "true"), propertiesMap.getOrElse("s3location", null), propertiesMap.getOrElse("samplesize", null))
+      dataframeFromTo.mongodbToDataFrame(propertiesMap("awsenv"), propertiesMap("cluster"), propertiesMap.getOrElse("overrideconnector", "false"), propertiesMap("database"), propertiesMap("authenticationdatabase"), propertiesMap("collection"), propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("vaultenv"), platformObject.optJSONObject("sparkoptions"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("authenticationenabled", "true"), propertiesMap.getOrElse("tmpfilelocation", null), propertiesMap.getOrElse("samplesize", null))
     }
     else if (platform == "kafka") {
       dataframeFromTo.kafkaToDataFrame(propertiesMap("bootstrapServers"), propertiesMap("topic"), propertiesMap("offset"), propertiesMap("schemaRegistries"), propertiesMap.getOrElse("keydeserializer", "org.apache.kafka.common.serialization.StringDeserializer"), propertiesMap("deSerializer"), propertiesMap.getOrElse("s3location", appConfig.s3bucket.toString + "/datapull-opensource/logs/"), propertiesMap.getOrElse("groupid", null), propertiesMap.getOrElse("requiredonlyvalue", "false"), propertiesMap.getOrElse("payloadcolumnname", "body"), migrationId, jobId, sparkSession, s3TempFolderDeletionError)
@@ -498,7 +498,6 @@ class Migration extends  SparkListener {
         tmpJsonObject.put("query",platformObject.get("post_migrate_command"))
         post_migrate_commands.put(tmpJsonObject)
       }
-
     }
 
 


### PR DESCRIPTION
# DataPull PR
We use the native connector by enabling `overrideconnector` flag for reading data from MongoDB with mongo collections having varying schemas it isn't working by throwing internal spark error.

### Added
NA

### Changed
* core/src/main/scala/core/Migration.scala
* core/src/main/scala/core/DataFrameFromTo.scala

### Deleted
NA


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
