### PR TITLE
Postgres bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [0.1.6] - 2020-05-22
+## [0.1.7] - 2020-05-22
 ### Changed
 * core/src/main/scala/core/DataFrameFromTo.scala
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.1.6] - 2020-05-22
 ### Changed
+* core/src/main/scala/core/DataFrameFromTo.scala
+
+## [0.1.6] - 2020-05-22
+### Changed
 * core/src/main/resources/Samples/Input_Json_Specification.json
 * core/src/main/scala/core/Controller.scala
 * core/src/main/scala/core/DataFrameFromTo.scala

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -1323,7 +1323,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline : String) extends Serializa
         driver = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
         url = "jdbc:sqlserver://" + server + ":" + (if (port == null) "1433" else port) + ";database=" + database
       }
-      else if (platform == "postgresql") {
+      else if (platform == "postgres") {
         driver = "org.postgresql.Driver"
         url = "jdbc:postgresql://" + server + ":" + (if (port == null) "5432" else port) + "/" + database + (if (sslEnabled == "true") "?sslmode=require" else "")
       }


### PR DESCRIPTION
# DataPull PR

There is a bug in the code when we check for assigning the driver based on the platform for running pre/post migrate commands for the Postgres data store.

### Changed
* core/src/main/scala/core/DataFrameFromTo.scala


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
