### PR TITLE
fix #67 by removing redundant -x in install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.9] - 2020-07-06
+### Changed
+* api/terraform/datapull_task/ecs_deploy.sh - Fixed bug issue #67
+
 ## [0.1.7] - 2020-05-22
 ### Changed
 * core/src/main/scala/core/DataFrameFromTo.scala

--- a/api/terraform/datapull_task/ecs_deploy.sh
+++ b/api/terraform/datapull_task/ecs_deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -x
+#!/usr/bin/env bash
 
 set -x
 


### PR DESCRIPTION
# DataPull PR

This fixes the issue where ecs_deploy.sh fails when installing DataPull from a Ubuntu linux client

### Changed
* api/terraform/datapull_task/ecs_deploy.sh - removed reduncant -x flag for bash which is achieved by `set -x` instead

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
