### PR TITLE
Update Migration.scala

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [0.1.23] - 2021-03-24
+## [0.1.24] - 2021-03-24
 ### changed
 - Migration.scala - Fix port issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.23] - 2021-03-24
+### changed
+- Migration.scala - Fix port issue
+
 ## [0.1.23] - 2021-03-14
 ### Added
 - manual-tests/filesyste_dataset_to_kafka* - Added manual test instructions to test data movement from filesystem to kafka topic

--- a/core/src/main/scala/core/Migration.scala
+++ b/core/src/main/scala/core/Migration.scala
@@ -428,7 +428,7 @@ class Migration extends SparkListener {
         propertiesMap("table")
       } else {
         "(" + sqlQuery + ") S"
-      }, propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("primarykey"), propertiesMap("lowerBound"), propertiesMap("upperBound"), propertiesMap("numPartitions"), propertiesMap("vaultenv"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("sslenabled", "false"), propertiesMap.getOrElse("vault", null), platformObject.optJSONObject("jdbcoptions"), propertiesMap.getOrElse("isWindowsAuthenticated", "false").toBoolean , propertiesMap.getOrElse("domain", null))
+      }, propertiesMap("login"), propertiesMap("password"), sparkSession, propertiesMap("primarykey"), propertiesMap("lowerBound"), propertiesMap("upperBound"), propertiesMap("numPartitions"), propertiesMap("vaultenv"), propertiesMap.getOrElse("secretstore", "vault"), propertiesMap.getOrElse("sslenabled", "false"), propertiesMap.getOrElse("port", null), platformObject.optJSONObject("jdbcoptions"), propertiesMap.getOrElse("isWindowsAuthenticated", "false").toBoolean , propertiesMap.getOrElse("domain", null))
     } else if (platform == "cassandra") {
       //DO NOT bring in the pre-migrate command in here, else it might run when getting the final counts
       propertiesMap = propertiesMap ++ deriveClusterIPFromConsul(jsonObjectPropertiesToMap(List("cluster", "cluster_key", "consul_dc"), platformObject))


### PR DESCRIPTION
# DataPull PR

Fix bug that takes in the "port" attribute for rdbms sources as "vault" attribute instead

### changed
- Migration.scala - Fix port issue


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
