### PR TITLE
Throw an exception to end the execution with exit code 1 when at least one migration has an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.26] - 2021-04-12
+### changed
+- Controller.scala - Throw an exception to end the execution with exit code 1 when at least one migration has an error. 
+
 ## [0.1.25] - 2021-03-24
 ### changed
 - Migration.scala - Fix port issue

--- a/core/src/main/scala/core/Controller.scala
+++ b/core/src/main/scala/core/Controller.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors
 import com.amazonaws.services.simpleemail.model.{Body, Content, Destination}
 import config.AppConfig
 import javax.mail._
+import helper._
 import javax.mail.internet.{InternetAddress, MimeMessage}
 import logging._
 import org.codehaus.jettison.json.JSONArray
@@ -41,6 +42,7 @@ class Controller(appConfig: AppConfig, pipeline : String)  {
   val alerts = new Alert(appConfig)
   val dataPullLogs = new DataPullLog(appConfig, pipeline)
   var env:String= null
+  val helper = new Helper(appConfig)
 
   def neatifyReportHtml(reportRowsHtml: String, reportCounts: Boolean, custom_retries: Boolean): String = {
     //make a table out of the body
@@ -166,6 +168,7 @@ class Controller(appConfig: AppConfig, pipeline : String)  {
             SendEmail(failureEmailAddress, updatedBodyHtml, applicationId, pipelineName, env, "Data Pull job failed for the Pipeline:" + awsenv + "- " + pipelineName + "-Pipeline (" + applicationId + ")", authenticatedUser)
           }
         }
+        throw new helper.CustomListOfExceptions(migrationErrors.mkString("\n"))
       }
       if (migrationErrors.isEmpty) {
         dataPullLogs.dataPullLogging(jobId, masterNode, ec2Role, portfolio, product, jsonString, stepSubmissionTime, Instant.now().toString, System.currentTimeMillis() - start_time_in_milli, "Completed", null, sparkSession)


### PR DESCRIPTION
# Exception on migration failure PR

The Datapull migration job does not return an error when there is a failure while running migrations. This behaviour provides no feedback when the migration fails.


### Changed
* Controller.scala
* Throw an exception to end the execution with exit code 1 when at least one migration has an error.



# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
