### PR TITLE
Egdm 187

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.43] - 2021-09-22
+
+-- adding optional forcerestart in datapull
+
+### Changed
+-  api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
+-  api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+-  api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+-  core/src/main/resources/Samples/Input_Json_Specification.json
+
 ## [0.1.42] - 2021-08-03
 
 - Fixed a bug which was mandating aws secret access key for every migration

--- a/api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
@@ -66,5 +66,8 @@ public class EMRProperties {
     @Value( "${bootstrap_folder_path:}" )
     private String bootstrapFolderPath;
 
+    @Value( "${forcerestart:false}" )
+    private Boolean forceRestart;
+
     private Map<String, String> tags = new HashMap<String, String>();
 }

--- a/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
@@ -106,6 +106,9 @@ public class ClusterProperties {
     @JsonProperty("bootstrapactionstring")
     private String bootstrapactionstring;
 
+    @JsonProperty("forcerestart")
+    private Boolean forceRestart;
+
     private String env;
 
     @Override
@@ -134,6 +137,7 @@ public class ClusterProperties {
                 ", env='" + env + '\'' +
                 ", brand='" + brand + '\'' +
                 ", costcenter='" + costCenter + '\'' +
+                ", forcerestart='" + forceRestart + '\'' +
                 ", application='" + application + '\'' +
                 '}';
     }

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -572,7 +572,10 @@
     "NodeCount": 6,
     "comment_sparksubmitparams": "optional, this option will give the ability to add the users to add the spark submit options for your use case",
     "sparksubmitparams": "--conf spark.driver.memory=10g --deploy-mode cluster --class DataMigrationFramework s3://BUCKET_NAME/FOLDER_PATH/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies_test.jar",
-    "comment_emr_service_role": "optional, thsi option should be used set the emr service role. Default: emr_datapull_role",
-    "emr_service_role": "emr_datapull_role"
+    "comment_emr_service_role": "optional, this option should be used set the emr service role. Default: emr_datapull_role",
+    "emr_service_role": "emr_datapull_role",
+    "comment_emr_service_role":"optional, this option should be used when running cluster will be terminated and new cluster is created. Default: false",
+    "forcerestart": false
+
   }
 }


### PR DESCRIPTION
# DataPull PR

_&lt;High level description of the PR&gt;_
adding optional forcerestart in datapull

### Added
* _&lt;detail item of what was added&gt;_
adding optional forcerestart in datapull
* _&lt;describe functionality added&gt;_
optional forcerestart will terminate existing same name of running cluster and start a new one if it is true

### Changed
* _&lt;detail item of what was changed&gt;_
-  api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
-  api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
-  api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
-  core/src/main/resources/Samples/Input_Json_Specification.json
* _&lt;describe functionality that was changed&gt;
optional forcerestart will terminate existing same name of running cluster and start a new one if it is true
* _&lt;in particular, describe BACKWARD INCOMPATIBLE changes&gt;
optional forcerestart default is false, so it is backward compatible

### Deleted
* _&lt;detail item of what was removed&gt;_
NA

# PR Checklist Forms

- [x ] CHANGELOG.md updated
- [ x] Reviewer assigned
- [ x] PR assigned (presumably to submitter)
- [ x] Labels added (enhancement, bug, documentation) 
