### PR TITLE
fix cluster optional forcerestart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.44] - 2021-09-27
+
+-- fix cluster optional forcerestart
+
+### Changed
+-  api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+
 ## [0.1.43] - 2021-09-22
 
--- adding optional forcerestart in datapull
+-- adding cluster optional forcerestart in datapull
 
 ### Changed
 -  api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java

--- a/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
@@ -107,7 +107,7 @@ public class ClusterProperties {
     private String bootstrapactionstring;
 
     @JsonProperty("forcerestart")
-    private Boolean forceRestart;
+    private Boolean forceRestart = false;
 
     private String env;
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -162,9 +162,11 @@ public class DataPullTask implements Runnable {
             if (summary != null && !forceRestart) {
                 this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
             } else if (summary != null && forceRestart) {
-                // kill cluster and start a new cluster
+                emr.setTerminationProtection(new SetTerminationProtectionRequest().withJobFlowIds(summary.getId()).withTerminationProtected(false));
                 emr.terminateJobFlows(new TerminateJobFlowsRequest().withJobFlowIds(summary.getId()));
+                DataPullTask.log.info("Task " + this.taskId + " is forced to be terminated");
                 this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
+                DataPullTask.log.info("Task " + this.taskId + " submitted to EMR cluster");
             }
 
         } else {

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -176,7 +176,7 @@ public class DataPullTask implements Runnable {
 
         if (!clusters.isEmpty()) {
             final ClusterSummary summary = clusters.get(0);
-            final Boolean forceRestart = clusterProperties.getForceRestart() != null && clusterProperties.getForceRestart();
+            final Boolean forceRestart = clusterProperties.getForceRestart() != null ? clusterProperties.getForceRestart() : false;
 
             if (summary != null && !forceRestart) {
                 this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -181,7 +181,6 @@ public class DataPullTask implements Runnable {
             if (summary != null && !forceRestart) {
                 this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
             } else if (summary != null && forceRestart) {
-                emr.setTerminationProtection(new SetTerminationProtectionRequest().withJobFlowIds(summary.getId()).withTerminationProtected(false));
                 emr.terminateJobFlows(new TerminateJobFlowsRequest().withJobFlowIds(summary.getId()));
                 DataPullTask.log.info("Task " + this.taskId + " is forced to be terminated");
                 this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -176,7 +176,7 @@ public class DataPullTask implements Runnable {
 
         if (!clusters.isEmpty()) {
             final ClusterSummary summary = clusters.get(0);
-            final Boolean forceRestart = clusterProperties.getForceRestart() != null ? clusterProperties.getForceRestart() : false;
+            final Boolean forceRestart = clusterProperties.getForceRestart();
 
             if (summary != null && !forceRestart) {
                 this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);


### PR DESCRIPTION
# DataPull PR

_&lt;High level description of the PR&gt;_
fix cluster optional forcerestart

### Added
* _&lt;detail item of what was added&gt;_
setTerminationProtection to false before terminate cluster
* _&lt;describe functionality added&gt;_
None

### Changed
* _&lt;detail item of what was changed&gt;_
api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
* _&lt;describe functionality that was changed&gt;
None
* _&lt;in particular, describe BACKWARD INCOMPATIBLE changes&gt;
there is no BACKWARD INCOMPATIBLE

### Deleted
* _&lt;detail item of what was removed&gt;_
NA

# PR Checklist Forms

- [ x] CHANGELOG.md updated
- [ x] Reviewer assigned
- [x ] PR assigned (presumably to submitter)
- [x ] Labels added (enhancement, bug, documentation) 
