### PR TITLE
Adding optional param for configuring subnet for EMR clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.45] - 2021-11-16
+
+Adding optional parameter for the user to configure subnet in which the EMR cluster can be spun up.
+
+### Changed 
+
+-  api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+-  api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+-  core/src/main/resources/Samples/Input_Json_Specification.json
+
 ## [0.1.44] - 2021-09-27
 
 -- fix cluster optional forcerestart

--- a/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
@@ -70,7 +70,7 @@ public class ClusterProperties {
     @JsonProperty("sparksubmitparams")
     private String sparksubmitparams;
 
-    @JsonProperty("subnet_id")
+    @JsonAlias({"subnet_id","subnet"})
     private String subnetId;
 
     @JsonAlias({"emr_instance_count", "nodecount", "NodeCount"})

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -233,7 +233,8 @@ public class DataPullTask implements Runnable {
         final String masterType = emrProperties.getMasterType();
         final DataPullProperties datapullProperties = this.config.getDataPullProperties();
 
-        final String applicationSubnet = datapullProperties.getApplicationSubnet1();
+
+        final String applicationSubnet = Objects.toString(this.clusterProperties.getSubnetId(),datapullProperties.getApplicationSubnet1());
 
         final int count = Integer.valueOf(Objects.toString(this.clusterProperties.getEmrInstanceCount(), Integer.toString(instanceCount)));
         final JobFlowInstancesConfig jobConfig = new JobFlowInstancesConfig()

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -575,7 +575,9 @@
     "comment_emr_service_role": "optional, this option should be used set the emr service role. Default: emr_datapull_role",
     "emr_service_role": "emr_datapull_role",
     "comment_emr_service_role":"optional, this option should be used when running cluster will be terminated and new cluster is created. Default: false",
-    "forcerestart": false
+    "forcerestart": false,
+    "comment_subnet_id": "Optional, the EMR cluster will be spun up in the default subnet of the environment if this is not provided by teh user",
+    "subnet_id": "application_subnet_1"
 
   }
 }

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -576,6 +576,8 @@
     "emr_service_role": "emr_datapull_role",
     "comment_emr_service_role":"optional, this option should be used when running cluster will be terminated and new cluster is created. Default: false",
     "forcerestart": false,
+    "comment_bootstrapactionstring": "Optional, it will add any additional commands which needs to be executed on the all the nodes as part of the bootstrap action",
+    "bootstrapactionstring": "sudo yum install openssl11-libs -y",
     "comment_subnet_id": "Optional, the EMR cluster will be spun up in the default subnet of the environment if this is not provided by teh user",
     "subnet_id": "application_subnet_1"
 


### PR DESCRIPTION
Adding optional parameter for the user to configure subnet in which the EMR cluster can be spun up.

### Changed 

-  api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
-  api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
-  core/src/main/resources/Samples/Input_Json_Specification.json


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
