### PR TITLE
upgrade log4j to fix vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.48] - 2021-12-15
+This is to upgrade the log4j to fix vulnerability
+
+Changed
+- core/pom.xml
+
 ## [0.1.47] - 2021-11-17
 
 This is to accept additional spark conf from the user for any migration 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.14.0</version>
+            <version>2.16.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
# DataPull PR

Upgrade the log4j-core to 2.14.0 due to a severe vulnerability
https://www.techtarget.com/searchsecurity/news/252510818/Critical-Apache-Log4j-2-bug-under-attack-mitigate-now

### Added
N/A

### Changed
* log4j-core version in the core/pom.xml

### Deleted
N/A


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
