### PR TITLE
Fixed issue of "bootstrapactionstring not working"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.51] - 2022-02-17
+
+This is the fix to a bug to make bootstrapactionstring work.
+
+### Changed
+
+- api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
+- api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+
 ## [0.1.50] - 2022-01-28
 
-THis is the fix to a bug in inline expression for jdbc code.
+This is the fix to a bug in inline expression for jdbc code.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [0.1.51] - 2022-02-18
+## [0.1.52] - 2022-02-18
 
 This is the fix to a bug to make bootstrapactionstring work.
 
@@ -18,6 +18,10 @@ This is the fix to a bug to make bootstrapactionstring work.
 - api/src/main/resources/application-prod.yml
 - api/src/main/resources/application-stage.yml
 - api/src/main/resources/application-test.yml
+- master_application_config-dev.yml
+- master_application_config-prod.yml
+- master_application_config-stage.yml
+- master_application_config-test.yml
 
 ## [0.1.50] - 2022-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
-## [0.1.51] - 2022-02-17
+## [0.1.51] - 2022-02-18
 
 This is the fix to a bug to make bootstrapactionstring work.
 
@@ -13,6 +13,11 @@ This is the fix to a bug to make bootstrapactionstring work.
 
 - api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
 - api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+- api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
+- api/src/main/resources/application-dev.yml
+- api/src/main/resources/application-prod.yml
+- api/src/main/resources/application-stage.yml
+- api/src/main/resources/application-test.yml
 
 ## [0.1.50] - 2022-01-28
 

--- a/api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/config/EMRProperties.java
@@ -68,6 +68,9 @@ public class EMRProperties {
 
     @Value( "${forcerestart:false}" )
     private Boolean forceRestart;
+    
+    @Value( "${default_bootstrapstring}" )
+    private String defaultBootstrapString;
 
     private Map<String, String> tags = new HashMap<String, String>();
 }

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
@@ -238,7 +238,7 @@ public class DataPullRequestProcessor implements DataPullClientService {
                 }
             }
         }
-        if (!list.isEmpty()) {
+        if (!list.isEmpty() || !bootstrapActionStringFromUser.isEmpty()) {
             stringBuilder = createBootstrapString(list.toArray(), bootstrapActionStringFromUser);
         }
         if (stringBuilder.length() > 0) {
@@ -249,7 +249,7 @@ public class DataPullRequestProcessor implements DataPullClientService {
 
     private DataPullTask createDataPullTask(String fileS3Path, String jksFilePath, ClusterProperties properties, String jobName, String creator, String customJarFilePath, List<String> bootstrapFilesList) {
         String creatorTag = String.join(" ", Arrays.asList(creator.split(",|;")));
-        DataPullTask task = config.getTask(jobName, fileS3Path, jksFilePath).withClusterProperties(properties).withCustomJar(customJarFilePath).bootstrapFilesList(bootstrapFilesList)
+        DataPullTask task = config.getTask(jobName, fileS3Path, jksFilePath).withClusterProperties(properties).withCustomJar(customJarFilePath).bootstrapFilesList(bootstrapFilesList).bootstrapActionStringFromUser(Objects.toString(properties.getBootstrapactionstring(), ""))
                 .addTag("Creator", creatorTag).addTag("Env", Objects.toString(properties.getAwsEnv(), env)).addTag("Name", jobName)
                 .addTag("AssetProtectionLevel", "99").addTag("ComponentInfo", properties.getComponentInfo())
                 .addTag("Portfolio", properties.getPortfolio()).addTag("Product", properties.getProduct()).addTag("Team", properties.getTeam()).addTag("tool", "datapull")

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -51,8 +51,7 @@ public class DataPullTask implements Runnable {
     private static final String JSON_WITH_INPUT_FILE_PATH = "{\r\n  \"jsoninputfile\": {\r\n    \"s3path\": \"%s\"\r\n  }\r\n}";
     private final Map<String, Tag> emrTags = new HashMap<>();
     private ClusterProperties clusterProperties;
-    private List<String> bootstrapFilesList;
-    private String bootstrapActionStringFromUser;
+    private Boolean haveBootstrapAction;
 
     public DataPullTask(final String taskId, final String s3File, final String jksFilePath) {
         s3FilePath = s3File;
@@ -163,16 +162,16 @@ public class DataPullTask implements Runnable {
             final Boolean forceRestart = clusterProperties.getForceRestart();
 
             if (summary != null && !forceRestart) {
-                this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
+                this.runTaskOnExistingCluster(summary.getId(), this.s3JarPath, Boolean.valueOf(Objects.toString(this.clusterProperties.getTerminateClusterAfterExecution(), "false")), Objects.toString(this.clusterProperties.getSparksubmitparams(), ""));
             } else if (summary != null && forceRestart) {
                 emr.terminateJobFlows(new TerminateJobFlowsRequest().withJobFlowIds(summary.getId()));
                 DataPullTask.log.info("Task " + this.taskId + " is forced to be terminated");
-                this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
+                this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), haveBootstrapAction);
                 DataPullTask.log.info("Task " + this.taskId + " submitted to EMR cluster");
             }
 
         } else {
-            final RunJobFlowResult result = this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), bootstrapFilesList);
+            final RunJobFlowResult result = this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), haveBootstrapAction);
         }
 
         DataPullTask.log.info("Task " + this.taskId + " submitted to EMR cluster");
@@ -208,7 +207,7 @@ public class DataPullTask implements Runnable {
         return sparkSubmitParamsList;
     }
 
-    private RunJobFlowResult runTaskInNewCluster(final AmazonElasticMapReduce emr, final String logPath, final String jarPath, final String sparkSubmitParams, final List<String> bootstrapFilesList) {
+    private RunJobFlowResult runTaskInNewCluster(final AmazonElasticMapReduce emr, final String logPath, final String jarPath, final String sparkSubmitParams, final Boolean haveBootstrapAction) {
 
         HadoopJarStepConfig runExampleConfig = null;
 
@@ -299,7 +298,7 @@ public class DataPullTask implements Runnable {
             request.withSecurityConfiguration(emrSecurityConfiguration);
         }
 
-        if (!bootstrapFilesList.isEmpty() || !bootstrapActionStringFromUser.isEmpty()) {
+        if (haveBootstrapAction) {
             final BootstrapActionConfig bsConfig = new BootstrapActionConfig();
             bsConfig.setName("bootstrapaction");
             bsConfig.setScriptBootstrapAction(new ScriptBootstrapActionConfig().withPath("s3://" + this.jksS3Path));
@@ -315,7 +314,7 @@ public class DataPullTask implements Runnable {
         this.addTags(tags);
     }
 
-    private void runTaskOnExistingCluster(final String id, final String jarPath, final boolean terminateClusterAfterExecution, final String sparkSubmitParams, final List<String> bootstrapFilesList) {
+    private void runTaskOnExistingCluster(final String id, final String jarPath, final boolean terminateClusterAfterExecution, final String sparkSubmitParams) {
 
         final List<String> sparkSubmitParamsList = this.prepareSparkSubmitParams(sparkSubmitParams);
 
@@ -401,14 +400,8 @@ public class DataPullTask implements Runnable {
         return this;
     }
 
-    public DataPullTask bootstrapFilesList(final List<String> bootstrapFilesList) {
-        this.bootstrapFilesList = bootstrapFilesList;
-        return this;
-    }
-    
-    
-    public DataPullTask bootstrapActionStringFromUser(final String bootstrapActionStringFromUser) {
-        this.bootstrapActionStringFromUser = bootstrapActionStringFromUser;
+    public DataPullTask haveBootstrapAction(final Boolean haveBootstrapAction) {
+        this.haveBootstrapAction = haveBootstrapAction;
         return this;
     }
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -52,6 +52,7 @@ public class DataPullTask implements Runnable {
     private final Map<String, Tag> emrTags = new HashMap<>();
     private ClusterProperties clusterProperties;
     private List<String> bootstrapFilesList;
+    private String bootstrapActionStringFromUser;
 
     public DataPullTask(final String taskId, final String s3File, final String jksFilePath) {
         s3FilePath = s3File;
@@ -298,7 +299,7 @@ public class DataPullTask implements Runnable {
             request.withSecurityConfiguration(emrSecurityConfiguration);
         }
 
-        if (!bootstrapFilesList.isEmpty()) {
+        if (!bootstrapFilesList.isEmpty() || !bootstrapActionStringFromUser.isEmpty()) {
             final BootstrapActionConfig bsConfig = new BootstrapActionConfig();
             bsConfig.setName("bootstrapaction");
             bsConfig.setScriptBootstrapAction(new ScriptBootstrapActionConfig().withPath("s3://" + this.jksS3Path));
@@ -402,6 +403,12 @@ public class DataPullTask implements Runnable {
 
     public DataPullTask bootstrapFilesList(final List<String> bootstrapFilesList) {
         this.bootstrapFilesList = bootstrapFilesList;
+        return this;
+    }
+    
+    
+    public DataPullTask bootstrapActionStringFromUser(final String bootstrapActionStringFromUser) {
+        this.bootstrapActionStringFromUser = bootstrapActionStringFromUser;
         return this;
     }
 

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -10,6 +10,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category:

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -10,6 +10,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category:

--- a/api/src/main/resources/application-stage.yml
+++ b/api/src/main/resources/application-stage.yml
@@ -10,6 +10,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category:

--- a/api/src/main/resources/application-test.yml
+++ b/api/src/main/resources/application-test.yml
@@ -10,6 +10,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category:

--- a/master_application_config-dev.yml
+++ b/master_application_config-dev.yml
@@ -35,6 +35,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category: EMRPipeline

--- a/master_application_config-prod.yml
+++ b/master_application_config-prod.yml
@@ -35,6 +35,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category: EMRPipeline

--- a/master_application_config-stage.yml
+++ b/master_application_config-stage.yml
@@ -35,6 +35,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category: EMRPipeline

--- a/master_application_config-test.yml
+++ b/master_application_config-test.yml
@@ -35,6 +35,7 @@ datapull:
     emr_security_group_master:
     emr_security_group_slave:
     emr_security_group_service_access:
+    default_bootstrapstring:
     tags:
       Brand:
       Category: EMRPipeline


### PR DESCRIPTION
# DataPull PR

Bug fix for bootstrapactionstring. Mainly changed `DataPullRequestProcess.java` and `DataPullTask.java`. Also changed 4 application YAML templates to support `default_bootstrapstring` feature. 
The detailed change is here: https://github.com/homeaway/datapull/pull/146/files. 
All the changes could also be found inside the commits associated with this PR. 

### Added
1. Added a `haveBootstrapAction` variable to replace checking if the `bootstrapFilesList` is empty to track if there is bootstrap action. 
2. Added a `haveBootstrapAction` method inside DataPullTask.java to pass on the value of `haveBootstrapAction`. 
3. Added `default_bootstrapstring` features to DataPullRequestProcess.java and updated application-dev.yml, application-prod.yml, application-stage.yml, and application-test.yml

### Changed
1. In DataPullRequestProcess.java, changed the inputs of `createBootstrapScript`, `createDataPullTask` methods. 
2. In DataPullTask.java, changed the inputs of `runTaskOnExistingCluster`, and `runTaskInNewCluster` methods. 

### Deleted
Deleted unnecessary inputs. 


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
