### PR TITLE
adding logging level for teradata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.51] - 2022-02-18
+
+THis is add an option to chose logging level by the user for teradata datstores. 
+
+### Changed
+
+- core/src/main/scala/helper/Helper.scala
+- core/src/main/scala/core/DataFrameFromTo.scala
+-  core/src/main/resources/Samples/Input_Json_Specification.json
+
 ## [0.1.50] - 2022-01-28
 
 THis is the fix to a bug in inline expression for jdbc code.

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -204,7 +204,9 @@
         "port": "1433/3306/1521/5432",
         "comment_jdbcoptions": "Optional, this json object accepts all jdbc configuration options which are related to jdbc datastores",
         "jdbcoptions": {
-          "fetchsize": "72000"
+          "fetchsize": "72000",
+          "comment_logging_level": "Optional, currently this is for Teradata datastore only. accepted values are ERROR/TIMING/INFO/DEBUG. more information can be found here: https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/jdbcug_chapter_2.html#URL_LOG",
+          "logging_level": "ERROR"
         },
         "comment_sslenabled": "optional, this option is currently supported for postgres",
         "sslenabled": false,

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -16,6 +16,14 @@
 
 package core
 
+import java.io.{File, PrintWriter, StringWriter}
+import java.nio.charset.StandardCharsets
+import java.sql._
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util
+import java.util.{Calendar, UUID}
+
 import com.amazonaws.services.logs.model.{DescribeLogStreamsRequest, InputLogEvent, PutLogEventsRequest}
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
@@ -30,6 +38,8 @@ import com.mongodb.{MongoClient, MongoClientURI}
 import config.AppConfig
 import core.DataPull.jsonObjectPropertiesToMap
 import helper._
+import javax.mail.internet.{InternetAddress, MimeMessage}
+import javax.mail.{Message, Session, Transport}
 import net.snowflake.spark.snowflake.Utils.SNOWFLAKE_SOURCE_NAME
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
@@ -47,15 +57,6 @@ import security._
 import za.co.absa.abris.avro.functions.{from_avro, to_avro}
 import za.co.absa.abris.config.FromAvroConfig
 
-import java.io.{File, PrintWriter, StringWriter}
-import java.nio.charset.StandardCharsets
-import java.sql._
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.util
-import java.util.{Calendar, UUID}
-import javax.mail.internet.{InternetAddress, MimeMessage}
-import javax.mail.{Message, Session, Transport}
 import scala.collection.JavaConversions._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer, StringBuilder}
 
@@ -1116,7 +1117,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
   }
 
   def rdbmsToDataFrame(platform: String, awsEnv: String, server: String, database: String, table: String, login: String, password: String, sparkSession: org.apache.spark.sql.SparkSession, primarykey: String, lowerbound: String, upperbound: String, numofpartitions: String, vaultEnv: String, secretStore: String, sslEnabled: Boolean, port: String, addlJdbcOptions: JSONObject, isWindowsAuthenticated: Boolean, domainName: String, typeForTeradata: Option[String]): org.apache.spark.sql.DataFrame = {
-    val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled)
+    val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled, addlJdbcOptions: JSONObject)
     val driver: String = configMap("driver")
     val url: String = configMap("url")
 
@@ -1174,7 +1175,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
   }
 
   def dataFrameToRdbms(platform: String, awsEnv: String, server: String, database: String, table: String, login: String, password: String, df: org.apache.spark.sql.DataFrame, vaultEnv: String, secretStore: String, sslEnabled: Boolean = false, port: String, addlJdbcOptions: JSONObject, savemode: String, isWindowsAuthenticated: Boolean, domainName: String, typeForTeradata: Option[String] = None): Unit = {
-    val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled)
+    val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled, addlJdbcOptions: JSONObject)
     val driver: String = configMap("driver")
     val url: String = configMap("url")
 
@@ -1253,7 +1254,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
     var resultSet:ResultSet = null
     if (sql_command != "") {
 
-      val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled)
+      val configMap = helper.buildRdbmsURI(platform, server, port, database, isWindowsAuthenticated, domainName, typeForTeradata, sslEnabled, null)
       val driver: String = configMap("driver")
       val url: String = configMap("url")
 


### PR DESCRIPTION
This is add an option to choose logging level by the user for Teradata datastores. 

### Changed

- core/src/main/scala/helper/Helper.scala
- core/src/main/scala/core/DataFrameFromTo.scala
-  core/src/main/resources/Samples/Input_Json_Specification.json


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
