### PR TITLE
Update log4j Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.57] - 2022-06/13
+
+Update log4j version to avoid security vulnerabilities. 
+
+### Changed
+
+- core/pom.xml
+- functional-test/pom.xml
+
 ## [0.1.56] - 2022-04-29
 
-This is add a feature for adding spark session properties for a job.
+This is to add a feature for adding spark session properties for a job.
 
 ### Changed
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.16.0</version>
+            <version>2.17.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.36</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>[2.13.2,)</version>
+            <version>[2.17.1,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz -->


### PR DESCRIPTION
# DataPull PR

User reported a log4j vulnerability caused by older log4j version, the issue is here: https://cve.report/CVE-2021-45046. 

According to https://mvnrepository.com, right now the log4j without security vulnerability is the version number >= 2.17.1, 
<img width="1236" alt="Screen Shot 2022-06-13 at 17 51 37" src="https://user-images.githubusercontent.com/22352252/173463560-2598e3f3-8e80-453d-8537-e61c1a759717.png">

Also updated the slf4j-log4j version to 1.7.36 where there is no security vulnerabilities. 

### Added
None

### Changed
1. core/pom.xml
2. functional-test/pom.xml

### Deleted
None


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
