### PR TITLE
Fix "logging level"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.58] - 2022-06/16
+
+Fixed `"logging_level"` in `"jdbcoptions"`
+
+### Changed
+
+- core/src/main/scala/helper/Helper.scala
+
 ## [0.1.57] - 2022-06/13
 
 Update log4j version to avoid security vulnerabilities. 

--- a/core/src/main/scala/helper/Helper.scala
+++ b/core/src/main/scala/helper/Helper.scala
@@ -311,7 +311,7 @@ class Helper(appConfig: AppConfig) {
   def buildTeradataURI(server: String, database: String, port: Option[Int], isWindowsAuthenticated: Boolean, typeForTeradata: Option[String], addlJdbcOptions: JSONObject): String = {
     var URI: String = null
     if (addlJdbcOptions != null && addlJdbcOptions.has("logging_level"))
-      "jdbc:teradata://" + server + "/" + (if (isWindowsAuthenticated) "LOGMECH=LDAP," else "") + "TYPE=" + typeForTeradata.getOrElse("DEFAULT") + ",DATABASE=" + database + ",TMODE=TERA,DBS_PORT=" + port.getOrElse(1025).toString + ",LOG=" + jsonObjectPropertiesToMap(addlJdbcOptions).get("logging_level")
+      "jdbc:teradata://" + server + "/" + (if (isWindowsAuthenticated) "LOGMECH=LDAP," else "") + "TYPE=" + typeForTeradata.getOrElse("DEFAULT") + ",DATABASE=" + database + ",TMODE=TERA,DBS_PORT=" + port.getOrElse(1025).toString + ",LOG=" + jsonObjectPropertiesToMap(addlJdbcOptions).get("logging_level").get
     else
       "jdbc:teradata://" + server + "/" + (if (isWindowsAuthenticated) "LOGMECH=LDAP," else "") + "TYPE=" + typeForTeradata.getOrElse("DEFAULT") + ",DATABASE=" + database + ",TMODE=TERA,DBS_PORT=" + port.getOrElse(1025).toString
   }


### PR DESCRIPTION
# DataPull PR

This PR is to fix the logging level. 

### Added
None

### Changed
The "logging_level" will return `"Some(DEBUG)"` instead of `DEBUG`. This is the current version: 
https://github.com/homeaway/datapull/blob/29040ed8f0d7920bd5cf13697bc404b1dfb00e4b/core/src/main/scala/helper/Helper.scala#L314

So add `.get` at the end of this line to let it return `DEBUG`. This is the updated version: 
https://github.com/homeaway/datapull/blob/6538301f20f5ff49a4248ef1baa2ba877377337e/core/src/main/scala/helper/Helper.scala#L314

### Deleted
None


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
