### PR TITLE
Spark env classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.64] - 2022-09-21
+
+ClusterProperties can now create EMR cluster configuration fields in the "spark-env" classification.
+
+### Changed
+
+- api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+- api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+
 ## [0.1.63] - 2022-07-23
 
 Adding functionality for adding custom bootstrap file while spinning up the EMR cluster.

--- a/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
@@ -86,6 +86,9 @@ public class ClusterProperties {
     @JsonProperty("spark_hive_properties")
     private Map<String, String> sparkHiveProperties = new HashMap<String, String>();
 
+    @JsonProperty("spark_env_properties")
+    private Map<String, String> sparkEnvProperties = new HashMap<String, String>();
+
     @JsonAlias({"ComponentInfo", "component_info"})
     private String componentInfo;
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -307,6 +307,8 @@ public class DataPullTask implements Runnable {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         hiveProperties.putAll(this.clusterProperties.getHiveProperties());
 
+        Map<String, String> sparkEnvProperties = this.clusterProperties.getSparkEnvProperties();
+
         Configuration sparkHiveConfig = new Configuration()
                 .withClassification("spark-hive-site")
                 .withProperties(sparkHiveProperties);
@@ -314,6 +316,10 @@ public class DataPullTask implements Runnable {
         Configuration hiveConfig = new Configuration()
                 .withClassification("hive-site")
                 .withProperties(hiveProperties);
+
+        Configuration sparkEnvConfig = new Configuration()
+                .withClassification("spark-env")
+                .withProperties(sparkEnvProperties);
 
         final RunJobFlowRequest request = new RunJobFlowRequest()
                 .withName(this.taskId)
@@ -333,6 +339,10 @@ public class DataPullTask implements Runnable {
 
         if (!sparkHiveProperties.isEmpty()) {
             request.withConfigurations(sparkHiveConfig);
+        }
+
+        if (!sparkEnvProperties.isEmpty()) {
+            request.withConfigurations(sparkEnvConfig);
         }
 
         if (!emrSecurityConfiguration.isEmpty()) {


### PR DESCRIPTION
The input json can now include the hashmap "spark_env_properties". Key/Values in this map are included as cluster configurations in the "spark-env" classification.

### Added


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
