### PR TITLE
sse kms functionality

### DIFF
--- a/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
+++ b/api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
@@ -83,6 +83,9 @@ public class ClusterProperties {
     @JsonProperty("hive_properties")
     private Map<String, String> hiveProperties = new HashMap<String, String>();
 
+    @JsonProperty("core_site_properties")
+    private Map<String, String> coreSiteProperties = new HashMap<String, String>();
+
     @JsonProperty("spark_hive_properties")
     private Map<String, String> sparkHiveProperties = new HashMap<String, String>();
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -343,6 +343,13 @@ public class DataPullTask implements Runnable {
                 .withTags(this.emrTags.values()).withConfigurations(new Configuration().withClassification("spark").withProperties(sparkProperties), myEmrfsConfig)
                 .withInstances(jobConfig);
 
+        if(!this.clusterProperties.getCoreSiteProperties().isEmpty()){
+            Configuration coreSiteConfig = new Configuration()
+                    .withClassification("core-site")
+                    .withProperties(this.clusterProperties.getCoreSiteProperties());
+            request.withConfigurations(coreSiteConfig);
+        }
+
         if (!hiveProperties.isEmpty()) {
             request.withConfigurations(hiveConfig);
         }

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -79,6 +79,10 @@
         "coalescefilecount": null,
         "comment_enable_server_side_encryption": "Optional, to access the buckets which have server side encryption enabled with AES 256 to be set true. Default: false",
         "enable_server_side_encryption": "false",
+        "comment_is_kms_enabled": "Optional, this should be set to `true` if the bucket you are reading SSE-KMS enabled",
+        "is_kms_enabled": "false",
+        "comment_kms_key_arn": "Optional, this is a mandatory field if the is_kms_enabled filed is set to true",
+        "kms_key_arn": "arn:aws:kms:<region>:<account-id>:key/<key-id>",
         "comment_post_migrate_command": "This is to execute copy/delete operation after the desired migration to s3",
         "post_migrate_command": {
           "comment_operation": "This field will take options either copy/delete.",
@@ -626,6 +630,10 @@
     "emr_security_configuration": "",
     "comment_spark_submit_arguments": "Optional, This is to override the default arguments for the spark submit command and this will remove the default arguments of teh datapull",
     "comment_tags": "Optional, this is to add any additional tags for the emr cluster",
+    "comment_core_site_properties": "Optional, if the user wants to set some core-site.xml settings while spinning up the emr cluster",
+    "core_site_properties": {
+      "fs.s3.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
+    },
     "tags": {
       "Creator": "email@domain.com",
       "costCenter": "012535"

--- a/core/src/main/scala/core/DataPull.scala
+++ b/core/src/main/scala/core/DataPull.scala
@@ -333,6 +333,10 @@ object DataPull {
       sparkSession.sparkContext.hadoopConfiguration.unset("fs." + s3Prefix + ".serverSideEncryptionAlgorithm")
       sparkSession.sparkContext.hadoopConfiguration.unset("fs." + s3Prefix + ".connection.ssl.enabled")
     }
+    if(sourceDestinationMap.contains("is_kms_enabled") && sourceDestinationMap("is_kms_enabled") == "true"){
+      sparkSession.sparkContext.hadoopConfiguration.set("fs." + s3Prefix + ".serverSideEncryptionAlgorithm","SSE-KMS")
+      sparkSession.sparkContext.hadoopConfiguration.set("fs." + s3Prefix + ".serverSideEncryptionAlgorithm",sourceDestinationMap("kms_key_arn"))
+    }
   }
 
   def jsonObjectPropertiesToMap(properties: List[String], jsonObject: JSONObject): Map[String, String] = {

--- a/core/src/main/scala/core/DataPull.scala
+++ b/core/src/main/scala/core/DataPull.scala
@@ -335,6 +335,7 @@ object DataPull {
     }
     if(sourceDestinationMap.contains("is_kms_enabled") && sourceDestinationMap("is_kms_enabled") == "true"){
       sparkSession.sparkContext.hadoopConfiguration.set("fs." + s3Prefix + ".serverSideEncryptionAlgorithm","SSE-KMS")
+      if(sourceDestinationMap.contains("kms_key_arn"))
       sparkSession.sparkContext.hadoopConfiguration.set("fs." + s3Prefix + ".serverSideEncryptionAlgorithm",sourceDestinationMap("kms_key_arn"))
     }
   }


### PR DESCRIPTION
# DataPull PR

This is to add functionality to enable reading sse-kms enabled buckets and adding functionality to take core-site configuration to the emr cluster.

### Changed
- api/src/main/java/com/homeaway/datapullclient/input/ClusterProperties.java
- api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
- core/src/main/resources/Samples/Input_Json_Specification.json
- core/src/main/scala/core/DataPull.scala

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
