### PR TITLE
Adding partitions to the mongo override connector and logging the run…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.69] - 2023-06-07
+we have added partitions for every batch we write to s3 to avoid file already existing errors. and added logging for run job flow request response.
+
+Changed
+api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+core/src/main/scala/core/DataFrameFromTo.scala
+
 ## [0.1.68] - 2023-06-07
 
 Fixed bug of missing bracket in the datapulltask file.

--- a/api/src/main/java/com/homeaway/datapullclient/api/DataPullClientApi.java
+++ b/api/src/main/java/com/homeaway/datapullclient/api/DataPullClientApi.java
@@ -55,7 +55,7 @@ public interface DataPullClientApi {
 
     String SIMPLE_ENDPOINT_NOTES_TEXT_HTML = "Give the inputs of environment name and pipeline name";
 
-    @ApiOperation(value = "Given a JSON input , this creates a Jenkins  pipline that can be scheduled to create an EMR cluster, run a DataPull step and terminates the cluster",
+    @ApiOperation(value = "Given a JSON input, creates an EMR cluster, run a DataPull step and terminates the cluster",
             consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE, response = ResponseEntity.class
     , notes = NOTES_TEXT_HTML, nickname = "startDatapull")
     @ResponseStatus(value = HttpStatus.ACCEPTED)

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -173,6 +173,7 @@ public class DataPullTask implements Runnable {
 
         } else {
             final RunJobFlowResult result = this.runTaskInNewCluster(emr, logPath, this.s3JarPath, Objects.toString(this.clusterProperties.getSparksubmitparams(), ""), haveBootstrapAction);
+            DataPullTask.log.info(result.toString());
         }
 
         DataPullTask.log.info("Task " + this.taskId + " submitted to EMR cluster");


### PR DESCRIPTION
# DataPull PR

we have added partitions for every batch we write to s3 to avoid file already existing errors. and added logging for run job flow request response. 

### Changed
* api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
* core/src/main/scala/core/DataFrameFromTo.scala

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
