### PR TITLE
EGDM-3362 - Datapull Jobs fails on duplicate subnet id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.70] - 2023-09-04
+Fixed bug of Jobs fails on duplicate subnet id
+
 ## [0.1.69] - 2023-06-07
 we have added partitions for every batch we write to s3 to avoid file already existing errors. and added logging for run job flow request response.
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -397,7 +397,7 @@ public class DataPullTask implements Runnable {
                 .withInstanceTypeConfigs(workerInstanceTypeConfig)
                 .withTargetOnDemandCapacity(count);
 
-        List<String> subnetIds= new ArrayList<>();
+        Set<String> subnetIds= new HashSet<>();
 
         subnetIds.addAll(toList(new String[]{dataPullProperties.getApplicationSubnet1(),
                 dataPullProperties.getApplicationSubnet2()}));

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -1277,7 +1277,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
         // create the statement, and run the command
         val statement = connection.createStatement()
 
-        if (colType != null) {
+        if (colType.isDefined) {
           resultSet=  statement.executeQuery(sql_command)
 
         }

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -1277,7 +1277,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
         // create the statement, and run the command
         val statement = connection.createStatement()
 
-        if (colType.isDefined) {
+        if (colType != null) {
           resultSet=  statement.executeQuery(sql_command)
 
         }


### PR DESCRIPTION
Fixed bug for datapull api if the customer providers any duplicate subnet from the default subnets for the respective account.

### Changed
api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java



# PR Checklist Forms

- [ X] CHANGELOG.md updated
- [ X] Reviewer assigned
- [ X] PR assigned (presumably to submitter)
- [X ] Labels added (enhancement, bug, documentation) 
