### PR TITLE
Usertag precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 
+## [0.1.72] - 2023-10-11
+We have modified the code for providing precedence to user tag over the default tags while EMR cluster creation.
+
+### Changed
+api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+
 ## [0.1.71] - 2023-09-04
 Fixed bug for datapull api if the customer providers any duplicate subnet from the default subnets for the respective account.
 

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -445,6 +445,7 @@ public class DataPullTask implements Runnable {
         final EMRProperties emrProperties = this.config.getEmrProperties();
         final Map<String, String> tags = this.config.getEmrProperties().getTags();
         this.addTags(tags);
+        this.addTags(clusterProperties.getTags()); //added for giving precedence to user tags
     }
 
     private void runTaskOnExistingCluster(final String id, final String jarPath, final boolean terminateClusterAfterExecution, final String sparkSubmitParams) {
@@ -499,7 +500,8 @@ public class DataPullTask implements Runnable {
     }
 
     public DataPullTask addTag(final String tagName, final String value) {
-        if (tagName != null && value != null && !this.emrTags.containsKey(tagName)) {
+        // if (tagName != null && value != null && !this.emrTags.containsKey(tagName)) { //Removed 
+        if (tagName != null && value != null) { // added to override the existing tags 
             final Tag tag = new Tag();
             tag.setKey(tagName);
             tag.setValue(value.replaceAll("[^a-z@ A-Z0-9_.:/=+\\\\-]", ""));


### PR DESCRIPTION
## [0.1.72] - 2023-10-11
We have modified the code for providing precedence to user tag over the default tags while EMR cluster creation.

### Changed
api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java