### PR TITLE
Randomly selecting one subnet_id 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.1.73] - 2023-10-27
 Randomly selecting one subnet_id to eliminate the load on any one subnet while submitting runjobflow requests. 
 
+### Changed
+api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+
 ## [0.1.72] - 2023-10-17
 Fixed bug for datapull subnet-id's issue (picking all default id's randomly)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.73] - 2023-10-27
+Randomly selecting one subnet_id (subnetid_issue_fix)
+
 ## [0.1.72] - 2023-10-17
 Fixed bug for datapull subnet-id's issue (picking all default id's randomly)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [0.1.73] - 2023-10-27
-Randomly selecting one subnet_id (subnetid_issue_fix)
+Randomly selecting one subnet_id to eliminate the load on any one subnet while submitting runjobflow requests. 
 
 ## [0.1.72] - 2023-10-17
 Fixed bug for datapull subnet-id's issue (picking all default id's randomly)

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -411,8 +411,8 @@ public class DataPullTask implements Runnable {
         }
         List<String> subnetIds_shuffled = new ArrayList<>(subnetIds);
         Collections.shuffle(subnetIds_shuffled, new Random());
-        List<String> subnetIds_shuffled_new = new ArrayList<>(subnetIds_shuffled);
-        System.out.println("Printing random subnet : " + subnetIds_shuffled_new.get(0));
+        
+        System.out.println("Printing random subnet : " + subnetIds_shuffled.get(0));
 
         final String masterSG = emrProperties.getEmrSecurityGroupMaster();
         final String slaveSG = emrProperties.getEmrSecurityGroupSlave();
@@ -425,7 +425,7 @@ public class DataPullTask implements Runnable {
                 this.clusterProperties.getServiceAccessSecurityGroup(), serviceAccesss != null ? serviceAccesss : "");
 
         final JobFlowInstancesConfig jobConfig = new JobFlowInstancesConfig()
-                .withEc2SubnetIds(subnetIds_shuffled_new.get(0))
+                .withEc2SubnetIds(subnetIds_shuffled.get(0))
                 .withInstanceFleets(masterInstanceFleetConfig)
                 .withKeepJobFlowAliveWhenNoSteps(!Boolean.valueOf(Objects.toString
                         (this.clusterProperties.getTerminateClusterAfterExecution(), "true")));

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -411,6 +411,8 @@ public class DataPullTask implements Runnable {
         }
         List<String> subnetIds_shuffled = new ArrayList<>(subnetIds);
         Collections.shuffle(subnetIds_shuffled, new Random());
+        List<String> subnetIds_shuffled_new = new ArrayList<>(subnetIds_shuffled);
+        System.out.println("Printing random subnet : " + subnetIds_shuffled_new.get(0));
 
         final String masterSG = emrProperties.getEmrSecurityGroupMaster();
         final String slaveSG = emrProperties.getEmrSecurityGroupSlave();
@@ -423,7 +425,7 @@ public class DataPullTask implements Runnable {
                 this.clusterProperties.getServiceAccessSecurityGroup(), serviceAccesss != null ? serviceAccesss : "");
 
         final JobFlowInstancesConfig jobConfig = new JobFlowInstancesConfig()
-                .withEc2SubnetIds(subnetIds_shuffled)
+                .withEc2SubnetIds(subnetIds_shuffled_new.get(0))
                 .withInstanceFleets(masterInstanceFleetConfig)
                 .withKeepJobFlowAliveWhenNoSteps(!Boolean.valueOf(Objects.toString
                         (this.clusterProperties.getTerminateClusterAfterExecution(), "true")));


### PR DESCRIPTION
# DataPull PR

Rotating the order of subnet IDs and picking the subnet that is being passed to runjobflow request so no subnet is overloaded. 

### Changed
* api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to the submitter)
- [ ] Labels added (enhancement, bug, documentation) 
