### PR TITLE
Mandating the Linux flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.1.78] - 2024-04-22
+Mandating the Linux flavor of the docker image that's been used in ECR.
+### Changed
+- API/terraform/datapull_task/ecs_deploy.sh
+
 ## [0.1.77] - 2024-04-10
 Fixing the null subnetId issue by adding  StringUtils.isNotBlank(dataPullProperties.getApplicationSubnet3())
 ### Changed

--- a/api/terraform/datapull_task/ecs_deploy.sh
+++ b/api/terraform/datapull_task/ecs_deploy.sh
@@ -179,7 +179,7 @@ exitAfterFailure
 ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-docker build -t "${docker_image_name}" .
+docker build --platform linux/amd64 -t "${docker_image_name}" .
 
 cd terraform/datapull_task
 


### PR DESCRIPTION
Mandating the Linux flavor of the docker image that's been used in ECR.

Changed
API/terraform/datapull_task/ecs_deploy.sh
# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
