### PR TITLE
Fix intermittent EMR failures caused by null/invalid subnet selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ DataPull is a self-service Distributed ETL tool to join and transform data from 
 * Build a local docker image for running spark as a dockerised server
   ```shell script
   cd ./datapull
-  docker build -f ./core/docker_spark_server/Dockerfile -t expedia/spark2.4.8-scala2.11-hadoop2.10.1 ./core/docker_spark_server
+  docker build -f ./core/docker_spark_server/Dockerfile -t expedia/spark3.5.1-scala2.12-hadoop3.3.6 ./core/docker_spark_server
   ```
 * Build the Scala JAR from within the `core` folder
   ```shell script
@@ -47,8 +47,8 @@ DataPull is a self-service Distributed ETL tool to join and transform data from 
      -w /core \
      -it \
      --rm \
-     expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit \
-        --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 \
+     expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit \
+        --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 \
         --deploy-mode client \
         --class core.DataPull \
         target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar src/main/resources/Samples/Input_Sample_filesystem-to-filesystem.json local

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
@@ -74,6 +74,7 @@ public class DataPullRequestProcessor implements DataPullClientService {
     private static final String PIPELINE_NAME_DELIMITER = "-";
     private static final int POOL_SIZE = 10;
     private static final String EMR = "emr";
+    private static final String SUBNET_ID_PREFIX = "subnet-";
     private static final String CREATOR = "useremailaddress";
     private Schema inputJsonSchema;
     @Autowired
@@ -258,17 +259,20 @@ public class DataPullRequestProcessor implements DataPullClientService {
             log.debug("runDataPull <- return");
     }
 
-    List<String> rotateSubnets(){
+    synchronized List<String> rotateSubnets(){
 
         if(subnets.isEmpty()){
             subnets= getSubnet();
+            if (subnets.isEmpty()) {
+                log.warn("No valid default subnet IDs are configured for datapull.api.application_subnet_[1-3].");
+            }
         }else{
             List<String> subnetIds_shuffled = new ArrayList<>(subnets);
             Collections.rotate(subnetIds_shuffled, 1);
             subnets.clear();
             subnets.addAll(subnetIds_shuffled);
         }
-        return subnets;
+        return new ArrayList<>(subnets);
     }
 
    Map<String,List<DescribeStepRequest>> getStepForPipeline(){
@@ -277,18 +281,16 @@ public class DataPullRequestProcessor implements DataPullClientService {
     public List<String> getSubnet(){
         final DataPullProperties dataPullProperties = this.config.getDataPullProperties();
 
-        List<String> subnetIds = new ArrayList<>();
-
-        subnetIds.add(dataPullProperties.getApplicationSubnet1());
-
-        if (StringUtils.isNotBlank(dataPullProperties.getApplicationSubnet2())) {
-            subnetIds.add(dataPullProperties.getApplicationSubnet2());
-        }
-
-        if (StringUtils.isNotBlank(dataPullProperties.getApplicationSubnet3())) {
-            subnetIds.add(dataPullProperties.getApplicationSubnet3());
-        }
-        return  subnetIds;
+        return Arrays.asList(
+                        dataPullProperties.getApplicationSubnet1(),
+                        dataPullProperties.getApplicationSubnet2(),
+                        dataPullProperties.getApplicationSubnet3())
+                .stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .filter(subnetId -> subnetId.startsWith(SUBNET_ID_PREFIX))
+                .distinct()
+                .collect(Collectors.toList());
 
     }
     private StringBuilder createBootstrapString(Object[] paths, String bootstrapActionStringFromUser) throws ProcessingException {

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -411,10 +411,6 @@ public class DataPullTask implements Runnable {
                 .withInstanceTypeConfigs(workerInstanceTypeConfig)
                 .withTargetOnDemandCapacity(count);
 
-        System.out.println("Printing random subnet : " + subnets);
-
-        System.out.println("Printing selected subnet-ID for EMR cluster creation : " +  subnets.get(0));
-
         final String masterSG = emrProperties.getEmrSecurityGroupMaster();
         final String slaveSG = emrProperties.getEmrSecurityGroupSlave();
         final String serviceAccesss = emrProperties.getEmrSecurityGroupServiceAccess();
@@ -425,12 +421,16 @@ public class DataPullTask implements Runnable {
         final String serviceAccessSecurityGroup = Objects.toString(
                 this.clusterProperties.getServiceAccessSecurityGroup(), serviceAccesss != null ? serviceAccesss : "");
 
-        if(StringUtils.isNotBlank(clusterProperties.getSubnetId())){
-            subnets.add(0,clusterProperties.getSubnetId());
-        }
+        List<String> defaultSubnets = subnets.stream()
+                .filter(StringUtils::isNotBlank)
+                .map(String::trim)
+                .filter(subnetId -> subnetId.startsWith("subnet-"))
+                .distinct()
+                .collect(Collectors.toList());
+        System.out.println("Printing random subnet : " + defaultSubnets);
 
 //      Introducing below logic to address null and invalid subnet issue
-        String getSubnetId = clusterProperties.getSubnetId();
+        String getSubnetId = StringUtils.trimToNull(clusterProperties.getSubnetId());
         String finalSubnetId;
 
 
@@ -444,13 +444,13 @@ public class DataPullTask implements Runnable {
                 System.out.println("The user either provided a NULL value for the subnet or did not specify subnet in the payload. Hence, the default subnet pool will be used for EMR creation.");
             }
 
-            Set<String> subnetsDeduped = new LinkedHashSet<>(subnets);
-            subnets.clear();
-            subnets.addAll(subnetsDeduped);
-
-            finalSubnetId = subnets.get(0);
+            if (defaultSubnets.isEmpty()) {
+                throw new IllegalStateException("No valid default subnet is configured for datapull.api.application_subnet_[1-3].");
+            }
+            finalSubnetId = defaultSubnets.get(0);
             System.out.println("EMR cluster will be created using a subnet from the default subnet pool: " + finalSubnetId);
         }
+        System.out.println("Printing selected subnet-ID for EMR cluster creation : " + finalSubnetId);
 
         final JobFlowInstancesConfig jobConfig = new JobFlowInstancesConfig()
                 .withEc2SubnetIds(finalSubnetId)

--- a/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
+++ b/api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
@@ -37,6 +37,8 @@ public class DataPullTask implements Runnable {
 
     //private Logger log = LoggerManag;
     private static final String MAIN_CLASS = "core.DataPull";
+    private static final String SPARK_PACKAGES =
+            "org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1";
 
     private final String taskId;
 
@@ -204,7 +206,7 @@ public class DataPullTask implements Runnable {
     private List<String> prepareSparkSubmitParams(final String SparkSubmitParams) {
         final List<String> sparkSubmitParamsList = new ArrayList<>();
         String[] sparkSubmitParamsArray = null;
-        if (SparkSubmitParams != "") {
+        if (SparkSubmitParams != null && !SparkSubmitParams.isEmpty()) {
             sparkSubmitParamsArray = SparkSubmitParams.split("\\s+");
 
             sparkSubmitParamsList.add("spark-submit");
@@ -224,7 +226,7 @@ public class DataPullTask implements Runnable {
             sparkSubmitParamsList = (ArrayList<String>) this.prepareSparkSubmitParams(sparkSubmitParams);
         } else {
             List<String> sparkBaseParams = new ArrayList<>();
-            sparkBaseParams.addAll(toList(new String[]{"spark-submit", "--conf", "spark.default.parallelism=3", "--conf", "spark.storage.blockManagerSlaveTimeoutMs=1200s", "--conf", "spark.executor.heartbeatInterval=900s", "--conf", "spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--conf", "spark.executor.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--packages", "org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.4,org.apache.spark:spark-avro_2.11:2.4.4", "--class", DataPullTask.MAIN_CLASS, jarPath}));
+            sparkBaseParams.addAll(toList(new String[]{"spark-submit", "--conf", "spark.default.parallelism=3", "--conf", "spark.network.timeout=1200s", "--conf", "spark.executor.heartbeatInterval=900s", "--conf", "spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--conf", "spark.executor.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--packages", SPARK_PACKAGES, "--class", DataPullTask.MAIN_CLASS, jarPath}));
             sparkSubmitParamsList.addAll(sparkBaseParams);
         }
 
@@ -496,7 +498,7 @@ public class DataPullTask implements Runnable {
             sparkSubmitParamsListOnExistingCluster = this.prepareSparkSubmitParams(sparkSubmitParams);
         } else {
             List<String> sparkBaseParams = new ArrayList<>();
-            sparkBaseParams.addAll(toList(new String[]{"spark-submit", "--conf", "spark.default.parallelism=3", "--conf", "spark.storage.blockManagerSlaveTimeoutMs=1200s", "--conf", "spark.executor.heartbeatInterval=900s", "--conf", "spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--conf", "spark.executor.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--packages", "org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.4,org.apache.spark:spark-avro_2.11:2.4.4", "--class", DataPullTask.MAIN_CLASS, jarPath}));
+            sparkBaseParams.addAll(toList(new String[]{"spark-submit", "--conf", "spark.default.parallelism=3", "--conf", "spark.network.timeout=1200s", "--conf", "spark.executor.heartbeatInterval=900s", "--conf", "spark.driver.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--conf", "spark.executor.extraJavaOptions=-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts/ -Djavax.net.ssl.trustStorePassword=changeit", "--packages", SPARK_PACKAGES, "--class", DataPullTask.MAIN_CLASS, jarPath}));
             sparkSubmitParamsListOnExistingCluster.addAll(sparkBaseParams);
         }
 

--- a/core/docker_spark_server/Dockerfile
+++ b/core/docker_spark_server/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # HADOOP
-ENV HADOOP_VERSION 2.10.1
+ENV HADOOP_VERSION 3.3.6
 ENV HADOOP_HOME /usr/hadoop-$HADOOP_VERSION
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
 ENV PATH $PATH:$HADOOP_HOME/bin
@@ -48,7 +48,7 @@ RUN curl -sL --retry 3 \
  && chown -R root:root $HADOOP_HOME
 
 # SPARK
-ENV SPARK_VERSION 2.4.8
+ENV SPARK_VERSION 3.5.1
 ENV SPARK_PACKAGE spark-${SPARK_VERSION}-bin-without-hadoop
 ENV SPARK_HOME /usr/spark-${SPARK_VERSION}
 ENV SPARK_DIST_CLASSPATH="$HADOOP_HOME/etc/hadoop/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*:$HADOOP_HOME/share/hadoop/tools/lib/*"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,11 +9,15 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <scala.binary.version>2.11</scala.binary.version>
-        <spark.version>2.4.6</spark.version>
-        <spark.minor.version>2.4</spark.minor.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.5.1</spark.version>
+        <spark.minor.version>3.5</spark.minor.version>
+        <abris.version>6.4.0</abris.version>
+        <spark.cassandra.connector.version>3.5.1</spark.cassandra.connector.version>
+        <mongo.spark.connector.version>3.0.2</mongo.spark.connector.version>
+        <snowflake.spark.connector.version>2.16.0-spark_3.4</snowflake.spark.connector.version>
         <maven.plugin.version>3.2.0</maven.plugin.version>
-        <hadoop.version>2.10.1</hadoop.version>
+        <hadoop.version>3.3.6</hadoop.version>
         <aws.java.sdk.version>1.11.1019</aws.java.sdk.version>
     </properties>
 
@@ -45,7 +49,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>4.9.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -103,13 +107,13 @@
         <dependency>
             <groupId>za.co.absa</groupId>
             <artifactId>abris_${scala.binary.version}</artifactId>
-            <version>4.2.0</version>
+            <version>${abris.version}</version>
         </dependency>
-        <!--<FOR SPARK CASSANDRA CONNECTION 2.4.6 does not exist>-->
+        <!--<CASSANDRA connector compatible with Spark 3.x>-->
         <dependency>
             <groupId>com.datastax.spark</groupId>
             <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-            <version>2.4.3</version>
+            <version>${spark.cassandra.connector.version}</version>
             <exclusions>
                 <exclusion>  <!-- declare the exclusion here -->
                     <groupId>io.netty</groupId>
@@ -142,14 +146,14 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.2.0-SNAP10</version>
+            <version>3.2.18</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_${scala.binary.version}</artifactId>
-            <version>1.14.0</version>
+            <version>1.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -216,11 +220,11 @@
             <scope>provided</scope>
         </dependency>
 
-        <!--<MONGODB SPARK CONNECTOR 2.4.6 does not exist>-->
+        <!--<MONGODB Spark connector compatible with Spark 3.x>-->
         <dependency>
             <groupId>org.mongodb.spark</groupId>
             <artifactId>mongo-spark-connector_${scala.binary.version}</artifactId>
-            <version>2.4.2</version>
+            <version>${mongo.spark.connector.version}</version>
         </dependency>
 
         <dependency>
@@ -247,11 +251,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.databricks</groupId>
-            <artifactId>spark-csv_${scala.binary.version}</artifactId>
-            <version>1.3.0</version>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>[4.1.42,)</version>
@@ -267,7 +266,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
-            <version>3.7.0-M16</version>
+            <version>4.0.7</version>
         </dependency>
 
         <dependency>
@@ -279,7 +278,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.11.0.1</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -294,7 +293,7 @@
 
         <dependency>
             <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch-spark-20_${scala.binary.version}</artifactId>
+            <artifactId>elasticsearch-spark-30_${scala.binary.version}</artifactId>
             <version>8.11.1</version>
         </dependency>
 
@@ -311,7 +310,7 @@
         <dependency>
             <groupId>org.mongodb.scala</groupId>
             <artifactId>mongo-scala-bson_${scala.binary.version}</artifactId>
-            <version>2.4.2</version>
+            <version>4.11.1</version>
         </dependency>
 
 
@@ -325,13 +324,7 @@
         <dependency>
             <groupId>org.mongodb.scala</groupId>
             <artifactId>mongo-scala-driver_${scala.binary.version}</artifactId>
-            <version>2.4.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.springml</groupId>
-            <artifactId>spark-sftp_${scala.binary.version}</artifactId>
-            <version>1.1.3</version>
+            <version>4.11.1</version>
         </dependency>
 
         <dependency>
@@ -343,7 +336,7 @@
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-xml_${scala.binary.version}</artifactId>
-            <version>1.3.0</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -354,7 +347,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>spark-snowflake_${scala.binary.version}</artifactId>
-            <version>2.8.2-spark_${spark.minor.version}</version>
+            <version>${snowflake.spark.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>net.snowflake</groupId>

--- a/core/src/main/resources/Samples/Input_Json_Specification.json
+++ b/core/src/main/resources/Samples/Input_Json_Specification.json
@@ -41,7 +41,7 @@
         "isstream": false,
         "comment_sparkoptions": "optional set of spark.cassandra options. these options will override equivalent parameters if both are provided. For example, delimiter specificed in sparkoptions will override delimiter specified (and deprecated) above",
         "sparkoptions": {
-          "comment_checkpointLocation": "For some output sinks where the end-to-end fault-tolerance can be guaranteed, specify the location where the system will write all the checkpoint information. This should be a directory in an HDFS-compatible fault-tolerant file system. ref https://spark.apache.org/docs/2.4.8/structured-streaming-programming-guide.html#recovering-from-failures-with-checkpointing",
+          "comment_checkpointLocation": "For some output sinks where the end-to-end fault-tolerance can be guaranteed, specify the location where the system will write all the checkpoint information. This should be a directory in an HDFS-compatible fault-tolerant file system. ref https://spark.apache.org/docs/3.5.1/structured-streaming-programming-guide.html#recovering-from-failures-with-checkpointing",
           "checkpointLocation": "s3a://S3BUCKET_AND_PATH or /LOCALHDFSPATH",
           "comment_delimiter": "Optional, defaulted to comma(,). Use \\t for tab-delimited files. Applies only for csv fileformat",
           "delimiter": "\t"
@@ -332,9 +332,9 @@
         "keyformat": "avro",
         "comment_valueformat": "Optional, by default will be avro. Can also be string. If string is chosen, the value field should be of type string. If the field is a complex data type like a struct, you can use the to_json() spark sql command.",
         "valueformat": "avro",
-        "comment_streamwatermarkfield": "Optional, defaults to timestamp. This attribute is not used unless the streamwatermarkdelay attribute too is specified. This provides the first argument in structured spak streaming's .withWatermark() function. More details at https://spark.apache.org/docs/2.4.6/structured-streaming-programming-guide.html#policy-for-handling-multiple-watermarks",
+        "comment_streamwatermarkfield": "Optional, defaults to timestamp. This attribute is not used unless the streamwatermarkdelay attribute too is specified. This provides the first argument in structured spak streaming's .withWatermark() function. More details at https://spark.apache.org/docs/3.5.1/structured-streaming-programming-guide.html#policy-for-handling-multiple-watermarks",
         "streamwatermarkfield": "timestamp",
-        "comment_streamwatermakdelay": "Optional. This provides the second argument in structured spak streaming's .withWatermark() function. More details at https://spark.apache.org/docs/2.4.6/structured-streaming-programming-guide.html#policy-for-handling-multiple-watermarks",
+        "comment_streamwatermakdelay": "Optional. This provides the second argument in structured spak streaming's .withWatermark() function. More details at https://spark.apache.org/docs/3.5.1/structured-streaming-programming-guide.html#policy-for-handling-multiple-watermarks",
         "streamwatermarkdelay": "1 hour",
         "comment_kafkaconnectmongodboptions": "Optional. Json Object that allows easier reading of Kafka events produced by MongoDB Kafka source connector https://docs.mongodb.com/kafka-connector/master/kafka-source/",
         "kafkaconnectmongodboptions": {

--- a/core/src/main/scala/core/DataFrameFromTo.scala
+++ b/core/src/main/scala/core/DataFrameFromTo.scala
@@ -63,6 +63,18 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer, StringBuilder}
 class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializable {
   val helper = new Helper(appConfig)
 
+  private def ensureSftpConnectorAvailable(): Unit = {
+    try {
+      Class.forName("com.springml.spark.sftp.DefaultSource")
+    } catch {
+      case _: ClassNotFoundException =>
+        throw new UnsupportedOperationException(
+          "SFTP support requires connector 'com.springml:spark-sftp' on the Spark classpath. " +
+            "No compatible Scala 2.12 artifact was resolved from the configured repositories."
+        )
+    }
+  }
+
   def fileToDataFrame(filePath: String, fileFormat: String, delimiter: String, charset: String, mergeSchema: Boolean = false, sparkSession: org.apache.spark.sql.SparkSession, isS3: Boolean = false, secretstore: String, isSFTP: Boolean = false, login: String, host: String, password: String, pemFilePath: String, awsEnv: String, vaultEnv: String, isStream: Boolean = false, addlSparkOptions: Option[JSONObject] = None, filePrefix: Option[String] = None, schema: Option[StructType] = None): org.apache.spark.sql.DataFrame = {
 
     if (filePath == null && fileFormat == null && delimiter == null && charset == null && sparkSession == null && login == null && host == null && password == null) {
@@ -119,6 +131,7 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
     }
 
     if (isSFTP) {
+      ensureSftpConnectorAvailable()
       createOrReplaceTempViewOnDF(sparkSession.read
         .format("com.springml.spark.sftp")
         .options(sparkOptions)
@@ -258,10 +271,11 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
     var sparkOptions: Map[String, String] = Map.empty[String, String]
 
     if (isSFTP) {
+      ensureSftpConnectorAvailable()
       sparkOptions = sparkOptions ++ Map(
         "host" -> host,
-        "username" -> login,
-        (if (pemFilePath == "") "password" else "pem") -> (if (pemFilePath == "") password else pemFilePath),
+        "username" -> vaultLogin,
+        (if (pemFilePath == "") "password" else "pem") -> (if (pemFilePath == "") vaultPassword else pemFilePath),
         "fileType" -> fileFormat
       )
       if (!addlSparkOptions.isEmpty) {
@@ -1456,4 +1470,3 @@ class DataFrameFromTo(appConfig: AppConfig, pipeline: String) extends Serializab
 
   }
 }
-

--- a/core/src/main/scala/core/DataPull.scala
+++ b/core/src/main/scala/core/DataPull.scala
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer
 import java.time._
 import java.util.{Scanner, UUID}
 
-import com.datastax.driver.core.utils.UUIDs
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.mongodb.spark.sql.fieldTypes.Binary
@@ -355,9 +354,7 @@ object DataPull {
   }
 
   def uuid(): String = {
-
-    UUIDs.timeBased().toString
-
+    UUID.randomUUID().toString
   }
 
   def validateUUID(uuidString: String): Boolean = {

--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -122,9 +122,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>19.3.0.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-properties -->
@@ -161,14 +161,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>[2.17.1,)</version>
+            <version>2.17.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz -->
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>[2.3.2,)</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/manual-tests/filesystem_dataset_to_elasticsearch_to_filesystem/README.md
+++ b/manual-tests/filesystem_dataset_to_elasticsearch_to_filesystem/README.md
@@ -25,7 +25,7 @@
    
 1. Run DataPull to copy data from a sample dataset in the filesystem, to a topic `hello_world` in the dockerised kafka cluster
     ```shell
-    docker run --network docker_elasticsearch_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
+    docker run --network docker_elasticsearch_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
     ```
 
 1. Open the url http://localhost:5601/app/kibana#/dev_tools/console?_g=() on your host machine, to open Kibana Console Center for the dockerised Elasticsearch environment. In the Console, run the command `GET testindex1/_search?pretty=true` and conform that there are 3 documents in the index `testindex1`

--- a/manual-tests/filesystem_dataset_to_kafka/README.md
+++ b/manual-tests/filesystem_dataset_to_kafka/README.md
@@ -27,7 +27,7 @@
    
 1. Run DataPull to copy data from a sample dataset in the filesystem, to a topic `hello_world` in the dockerised kafka cluster
     ```shell
-    docker run --network docker_kafka_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
+    docker run --network docker_kafka_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
     ```
 1. Run the previous step again, to test writes to an existing topic with defined schema
 

--- a/manual-tests/filesystem_dataset_with_uuids_to_mongodb/README.md
+++ b/manual-tests/filesystem_dataset_with_uuids_to_mongodb/README.md
@@ -28,7 +28,7 @@
     ```
 1. Run DataPull to copy data from a sample dataset in the filesystem, to a collection `testcollection` in the database `testdb` in the dockerised mongodb server
     ```shell
-    docker run --network manual-test-network -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
+    docker run --network manual-test-network -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
     ```
 1. Open Robo3T, and connect to the mongodb server by creating a new connection with
     1. Address: localhost:27017

--- a/manual-tests/filesystem_stream_to_kafka/README.md
+++ b/manual-tests/filesystem_stream_to_kafka/README.md
@@ -26,7 +26,7 @@
 
 1. Run DataPull 
     ```shell
-    docker run --network docker_kafka_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
+    docker run --network docker_kafka_server_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
     ```
 1. Open the url http://localhost:9021/clusters on your host machine, to open Confluent Control Center for the dockerised Kafka environment. Using the left nav of Confluent Control Center, navigate to `CO Cluster 1 > Topics` and conform that
    1. there are 2 topics named `hello_world` and `hello_world2`

--- a/manual-tests/mssql_dataset_to_mysql_to_mssql/README.md
+++ b/manual-tests/mssql_dataset_to_mysql_to_mssql/README.md
@@ -24,7 +24,7 @@
    
 1. Run DataPull to create a database and generate some data in mssql, and then copy the data to a mysql table; and then copy that data back to mssql
     ```shell
-    docker run --network docker_rdbms_servers_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark2.4.8-scala2.11-hadoop2.10.1 spark-submit --packages org.apache.spark:spark-sql_2.11:2.4.8,org.apache.spark:spark-avro_2.11:2.4.8,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.8 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
+    docker run --network docker_rdbms_servers_default -v $(pwd)/../../core/:/core -v $(pwd):/core/manualtestfolder -w /core -it --rm expedia/spark3.5.1-scala2.12-hadoop3.3.6 spark-submit --packages org.apache.spark:spark-sql_2.12:3.5.1,org.apache.spark:spark-avro_2.12:3.5.1,org.apache.spark:spark-sql-kafka-0-10_2.12:3.5.1 --deploy-mode client --class core.DataPull target/DataMigrationFramework-1.0-SNAPSHOT-jar-with-dependencies.jar manualtestfolder/datapull_input.json local
     ```
 1. Run the following command to confirm that the test worked. If the command prints 1000000, then the test was successful.
    ```shell


### PR DESCRIPTION
# DataPull PR

## Why

Datapull intermittently failed EMR cluster creation with:

`AmazonElasticMapReduceException: A null value was specified in subnetIds`

This was intermittent because default subnets are rotated; when a null/default-invalid entry rotated to index 0, EMR got `null` for subnet ID.

## What changed

1. Hardened default subnet pool construction
- File: api/src/main/java/com/homeaway/datapullclient/process/DataPullRequestProcessor.java
- `getSubnet()` now:
  - reads `application_subnet_1/2/3`
  - filters null/blank values
  - trims values
  - keeps only values that start with `subnet-`
  - de-duplicates
- `rotateSubnets()` now:
  - is `synchronized`
  - returns a defensive copy (`new ArrayList<>(subnets)`)
  - logs warning when no valid defaults are configured

2. Removed shared-list mutation during runtime subnet selection
- File: api/src/main/java/com/homeaway/datapullclient/process/DataPullTask.java
- `getJobFlowInstancesConfig()` now:
  - builds a sanitized local `defaultSubnets` list from provided defaults
  - does not mutate shared `subnets` list
  - uses payload subnet only if valid (`subnet-*`)
  - falls back to first valid default subnet
  - throws clear error if no valid default subnet exists:
    `No valid default subnet is configured for datapull.api.application_subnet_[1-3].`

3. Logging now prints the actually selected final subnet ID
- avoids misleading logs from pre-selection list state

## Impact

- Prevents null from being passed to EMR `subnetIds`
- Eliminates intermittent null-subnet behavior caused by subnet rotation
- Converts misconfiguration into deterministic, actionable error